### PR TITLE
Modify template email styles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: 119.0.6045.105
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -328,7 +328,7 @@
           </td>
           <td class="footer-social__wrap" style="padding-top: 24px">
             <%= translated_text_for :footer_social_links_title %>
-            <div class="footer-social" >
+            <div class="footer-social">
               <%= social_links.join.html_safe %>
             </div>
           </td>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -222,7 +222,7 @@
               <table class="row content image">
                 <tr>
                   <th class="small-12 first columns">
-                    <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]) %>
+                    <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]), width: "653", height: "436" %>
                   </th>
                   <th class="expander"></th>
                 </tr>
@@ -260,7 +260,7 @@
                       <div class="box-image">
                         <% if has_image?("body_box_image_#{num}") %>
                           <%= link_to link_for("body_box_link_url_#{num}") do %>
-                            <%= image_tag(image_url("body_box_image_#{num}")) %>
+                            <%= image_tag(image_url("body_box_image_#{num}", resize_to_fill: [238, 134]), width: "238", height: "134", style: "width:100%; max-width:100%; display:block; margin:0 auto;") %>
                           <% end %>
                         <% end %>
                       </div>
@@ -305,7 +305,7 @@
           <% (1..3).each do |num| %>
             <td class="footer-box" style="padding: 10px;margin-bottom: 30px;" width="33%">
               <div class="box-image">
-                <%= image_tag(image_url("footer_box_image_#{num}", resize_to_fill: [198, 132])) if has_image?("footer_box_image_#{num}") %>
+                <%= image_tag(image_url("footer_box_image_#{num}", resize_to_fill: [198, 132]), width: "198", height: "132") if has_image?("footer_box_image_#{num}") %>
               </div>
               <div class="footer-box-date-time">
                 <%= translated_text_for "footer_box_date_time_#{num}" %>
@@ -342,7 +342,7 @@
         <table class="footer-logo" style="margin: 0;">
           <tr>
             <td class="footer-bottom" style="padding: 20px 0;">
-              <%= image_tag footer_image_url, class: "footer-bottom__logo" %>
+              <%= image_tag footer_image_url, class: "footer-bottom__logo", width: "124", height: "80" %>
             </td>
           </tr>
         </table>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -6,6 +6,17 @@
     background: <%= background_color %> !important;
   }
 
+  table {
+    border-collapse: collapse !important;
+  }
+
+  mso-table-lspace: 0pt;
+  mso-table-rspace: 0pt;
+
+  img {
+        -ms-interpolation-mode: bicubic;
+  }
+
   table.container,
   table.container td,
   table.container p,

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -240,7 +240,7 @@
   </tr>
   <tr>
     <td class="agenda">
-      <table class="agenda">
+      <table class="agenda" width="100%">
         <tr>
           <td class="top" style="vertical-align: middle; padding: 0 120px; text-align: center; font-size:24px;"
               colspan="2">
@@ -251,8 +251,8 @@
           </td>
         </tr>
         <tr>
-          <td class="middle">
-            <table cellpadding="0" cellspacing="0" border="0" align="center">
+          <td class="middle" width="100%">
+            <table cellpadding="0" cellspacing="0" border="0" align="center" width="100%">
               <% (1..4).each_slice(2) do |boxes| %>
                 <tr>
                   <% boxes.each do |num| %>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -6,17 +6,6 @@
     background: <%= background_color %> !important;
   }
 
-  table {
-    border-collapse: collapse !important;
-  }
-
-  mso-table-lspace: 0pt;
-  mso-table-rspace: 0pt;
-
-  img {
-        -ms-interpolation-mode: bicubic;
-  }
-
   table.container,
   table.container td,
   table.container p,
@@ -233,7 +222,7 @@
               <table class="row content image">
                 <tr>
                   <th class="small-12 first columns">
-                    <%= image_tag(image_url(:main_image, resize_to_fit: [653, 436]), width: "653", height: "436") %>
+                    <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]) %>
                   </th>
                   <th class="expander"></th>
                 </tr>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -152,8 +152,8 @@
   .footer-social__icon {
     display: inline-block;
     margin-right: 0.5rem;
-    width: 20px;
-    height: 20px;
+    width: 20px !important;
+    height: 20px !important;
   }
 
   .footer-social__icon:last-child {

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -233,7 +233,7 @@
               <table class="row content image">
                 <tr>
                   <th class="small-12 first columns">
-                    <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]) %>
+                    <%= image_tag(image_url(:main_image, resize_to_fit: [653, 436]), width: "653", height: "436") %>
                   </th>
                   <th class="expander"></th>
                 </tr>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -287,7 +287,7 @@
         <tr style="text-align: center;vertical-align: middle;">
           <td class="bottom" style="text-align: center;vertical-align: middle;">
             <%= translated_text_for :body_final_text %>
-            <%= image_tag asset_pack_url("media/images/arrow-down.png", **host_options), display: "block", margin-top: "1rem" %>
+            <%= image_tag asset_pack_url("media/images/arrow-down.png", **host_options), style: "display: block;  margin-top: 1rem;" %>
           </td>
         </tr>
       </table>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -165,6 +165,11 @@
     margin: 0 auto;
   }
 
+  img {
+    -ms-interpolation-mode: nearest-neighbor;
+    -ms-interpolation-mode: bicubic;
+  }
+
   @media only screen and (max-width: 500px) {
     .event-box,
     .footer-box {
@@ -220,8 +225,8 @@
           <tr>
             <td>
               <table class="row content image">
-                <tr>
-                  <th class="small-12 first columns">
+                <tr align="center">
+                  <th class="small-12 first columns" align="center">
                     <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]), width: "653", height: "436" %>
                   </th>
                   <th class="expander"></th>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -260,7 +260,7 @@
                       <div class="box-image">
                         <% if has_image?("body_box_image_#{num}") %>
                           <%= link_to link_for("body_box_link_url_#{num}") do %>
-                            <%= image_tag(image_url("body_box_image_#{num}", resize_to_fill: [238, 134]), width: "238", height: "134", style: "width:100%; max-width:100%; display:block; margin:0 auto;") %>
+                            <%= image_tag(image_url("body_box_image_#{num}"), width: "238", height: "134", style: "width:100%; max-width:500px; display:block; margin:0 auto;") %>
                           <% end %>
                         <% end %>
                       </div>
@@ -287,7 +287,7 @@
         <tr style="text-align: center;vertical-align: middle;">
           <td class="bottom" style="text-align: center;vertical-align: middle;">
             <%= translated_text_for :body_final_text %>
-            <%= image_tag asset_pack_url("media/images/arrow-down.png", **host_options), style: "display: block;  margin-top: 1rem;" %>
+            <%= image_tag asset_pack_url("media/images/arrow-down.png", **host_options) %>
           </td>
         </tr>
       </table>
@@ -328,7 +328,7 @@
           </td>
           <td class="footer-social__wrap" style="padding-top: 24px">
             <%= translated_text_for :footer_social_links_title %>
-            <div class="footer-social">
+            <div class="footer-social" >
               <%= social_links.join.html_safe %>
             </div>
           </td>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/canodrom.erb
@@ -287,7 +287,7 @@
         <tr style="text-align: center;vertical-align: middle;">
           <td class="bottom" style="text-align: center;vertical-align: middle;">
             <%= translated_text_for :body_final_text %>
-            <%= image_tag asset_pack_url("media/images/arrow-down.png", **host_options) %>
+            <%= image_tag asset_pack_url("media/images/arrow-down.png", **host_options), display: "block", margin-top: "1rem" %>
           </td>
         </tr>
       </table>
@@ -342,7 +342,7 @@
         <table class="footer-logo" style="margin: 0;">
           <tr>
             <td class="footer-bottom" style="padding: 20px 0;">
-              <%= image_tag footer_image_url, class: "footer-bottom__logo", width: "124", height: "80" %>
+              <%= image_tag footer_image_url, class: "footer-bottom__logo", width: "180", height: "80" %>
             </td>
           </tr>
         </table>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -107,9 +107,9 @@
       <!-- Intro-content -->
       <table width="100%" border="0" cellpadding="0" cellspacing="0" style="background-color: <%= background_color %>;">
         <tr>
-          <td align="center" style="padding: 48px">
+          <td align="center" style="padding: 48px; width: 653px; height: 436px;">
             <% if has_image?(:main_image) %>
-              <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]), alt: "Intro Image", width: "653", height: "436", style: "width: 100%; height: auto;" %>
+              <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]), alt: "Intro Image", width: "653", height: "436" %>
             <% end %>
           </td>
         </tr>
@@ -148,7 +148,7 @@
                         <!-- Image -->
                         <% if has_image?("body_box_image_#{num}") %>
                           <%= link_to link_for("body_box_link_url_#{num}") do %>
-                            <%= image_tag(image_url("body_box_image_#{num}", resize_to_fill: [238, 134]), width: "238", height: "134", style: "width:100%; max-width:500px; display:block; margin:0 auto;") %>
+                            <%= image_tag(image_url("body_box_image_#{num}"), width: "238", height: "134", style: "width:100%; max-width:500px; display:block; margin:0 auto;") %>
                           <% end %>
                         <% end %>
 

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -148,7 +148,7 @@
                         <!-- Image -->
                         <% if has_image?("body_box_image_#{num}") %>
                           <%= link_to link_for("body_box_link_url_#{num}") do %>
-                            <%= image_tag(image_url("body_box_image_#{num}", resize_to_fill: [198, 132]), width: "198", height: "132", style: "width:100%; max-width:100%; display:block; margin:0 auto;") %>
+                            <%= image_tag(image_url("body_box_image_#{num}", resize_to_fill: [238, 134]), width: "238", height: "134", style: "width:100%; max-width:100%; display:block; margin:0 auto;") %>
                           <% end %>
                         <% end %>
 

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -5,9 +5,6 @@
     padding: 0 !important;
   }
 
-  mso-table-lspace: 0pt;
-  mso-table-rspace: 0pt;
-
   .introduction-text,
   .introduction-text p {
     font-size: 18px !important;
@@ -61,10 +58,6 @@
     height: 25px;
   }
 
-    img {
-        -ms-interpolation-mode: bicubic;
-    }
-
   @media only screen and (max-width: 400px) {
     td.mobile-responsive {
       width: 100% !important;
@@ -97,7 +90,21 @@
   }
 </style>
 
-<table class="main container" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #ffffff; border-collapse: collapse !important;">
+<if mso>
+  <style type="text/css">
+      table {
+          border-collapse: collapse !important;
+      }
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+      img {
+          -ms-interpolation-mode: bicubic;
+      }
+  </style>
+<endif>
+
+
+<table class="main container" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #ffffff;">
   <tr>
     <td>
       <!-- Logo -->
@@ -116,7 +123,7 @@
         <tr>
           <td align="center" style="padding: 48px">
             <% if has_image?(:main_image) %>
-              <%= image_tag(image_url(:main_image, resize_to_fit: [653, 436]), alt: "Intro Image", width: "653", height: "436", style: "width: 100%; height: auto;") %>
+              <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]), alt: "Intro Image", width: "653", height: "436", style: "width: 100%; height: auto;" %>
             <% end %>
           </td>
         </tr>
@@ -213,7 +220,7 @@
                   <td class="mobile-responsive footer-box__image" style="width: 33.33%; vertical-align: top; padding: 08px;">
                     <!-- Image -->
                     <% if has_image?("footer_box_image_#{num}") %>
-                      <%= image_tag(image_url("footer_box_image_#{num}", resize_to_fill: [198, 132]), width: 198, height: 132) %>
+                      <%= image_tag(image_url("footer_box_image_#{num}", resize_to_fill: [198, 132]), width: "198", height: "132", style: "width: 100%; height: auto;") %>
                     <% end %>
                     <!-- Date -->
                     <table width="100%">
@@ -289,9 +296,9 @@
                 <td class="mobile-responsive logos-block" style="padding: 0 32px 0 0;vertical-align: bottom;">
                   <table border="0" cellspacing="0" cellpadding="0">
                     <tr class="footer-logos">
-                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options) %></td>
-                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options) %></td>
-                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options) %></td>
+                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options), style: "width: 100px; height: auto;" %></td>
+                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options), style: "width: 100px; height: auto;" %></td>
+                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options), style: "width: 100px; height: auto;" %></td>
                     </tr>
                   </table>
                 </td>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -148,7 +148,7 @@
                         <!-- Image -->
                         <% if has_image?("body_box_image_#{num}") %>
                           <%= link_to link_for("body_box_link_url_#{num}") do %>
-                            <%= image_tag(image_url("body_box_image_#{num}"), style: "width:100%; max-width:500px; display:block; margin:0 auto;") %>
+                            <%= image_tag(image_url("body_box_image_#{num}", resize_to_fill: [198, 132]), width: "198", height: "132", style: "width:100%; max-width:100%; display:block; margin:0 auto;") %>
                           <% end %>
                         <% end %>
 

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -148,7 +148,7 @@
                         <!-- Image -->
                         <% if has_image?("body_box_image_#{num}") %>
                           <%= link_to link_for("body_box_link_url_#{num}") do %>
-                            <%= image_tag(image_url("body_box_image_#{num}", resize_to_fill: [238, 134]), width: "238", height: "134", style: "width:100%; max-width:100%; display:block; margin:0 auto;") %>
+                            <%= image_tag(image_url("body_box_image_#{num}", resize_to_fill: [238, 134]), width: "238", height: "134", style: "width:100%; max-width:500px; display:block; margin:0 auto;") %>
                           <% end %>
                         <% end %>
 
@@ -282,9 +282,9 @@
                 <td class="mobile-responsive logos-block" style="padding: 0 32px 0 0;vertical-align: bottom;">
                   <table border="0" cellspacing="0" cellpadding="0">
                     <tr class="footer-logos">
-                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options, resize_to_fit: [138, 25]), width: "180", height: "25" %></td>
-                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options, resize_to_fit: [66, 25]), width: "120", height: "25" %></td>
-                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options, resize_to_fit: [51, 25]), width: "140", height: "25" %></td>
+                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options), width: "180", height: "25" %></td>
+                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options), width: "100", height: "25" %></td>
+                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options), width: "80", height: "25" %></td>
                     </tr>
                   </table>
                 </td>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -103,7 +103,6 @@
   </style>
 <endif>
 
-
 <table class="main container" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #ffffff;">
   <tr>
     <td>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -282,9 +282,9 @@
                 <td class="mobile-responsive logos-block" style="padding: 0 32px 0 0;vertical-align: bottom;">
                   <table border="0" cellspacing="0" cellpadding="0">
                     <tr class="footer-logos">
-                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options, resize_to_fit: [138, 25]), width: "138", height: "25" %></td>
-                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options, resize_to_fit: [66, 25]), width: "66", height: "25" %></td>
-                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options, resize_to_fit: [51, 25]), width: "51", height: "25" %></td>
+                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options, resize_to_fit: [138, 25]), width: "180", height: "25" %></td>
+                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options, resize_to_fit: [66, 25]), width: "120", height: "25" %></td>
+                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options, resize_to_fit: [51, 25]), width: "140", height: "25" %></td>
                     </tr>
                   </table>
                 </td>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -58,6 +58,11 @@
     height: 25px;
   }
 
+  img {
+    -ms-interpolation-mode: nearest-neighbor;
+    -ms-interpolation-mode: bicubic;
+  }
+
   @media only screen and (max-width: 400px) {
     td.mobile-responsive {
       width: 100% !important;

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -54,7 +54,7 @@
   }
 
   .footer-logos img {
-    width: auto;
+    width: 100px;
     height: 25px;
   }
 

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -94,7 +94,6 @@
     .social-links {
       padding-top: 20px !important;
     }
-    
   }
 </style>
 
@@ -117,7 +116,7 @@
         <tr>
           <td align="center" style="padding: 48px">
             <% if has_image?(:main_image) %>
-              <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]), alt: "Intro Image" %>
+              <%= image_tag(image_url(:main_image, resize_to_fit: [653, 436]), alt: "Intro Image", width: "653", height: "436", style: "width: 100%; height: auto;") %>
             <% end %>
           </td>
         </tr>
@@ -214,7 +213,7 @@
                   <td class="mobile-responsive footer-box__image" style="width: 33.33%; vertical-align: top; padding: 08px;">
                     <!-- Image -->
                     <% if has_image?("footer_box_image_#{num}") %>
-                      <%= image_tag(image_url("footer_box_image_#{num}", resize_to_fill: [198, 132])) %>
+                      <%= image_tag(image_url("footer_box_image_#{num}", resize_to_fill: [198, 132]), width: 198, height: 132) %>
                     <% end %>
                     <!-- Date -->
                     <table width="100%">

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -54,7 +54,7 @@
   }
 
   .footer-logos img {
-    width: 100px;
+    width: auto;
     height: 25px;
   }
 
@@ -89,19 +89,6 @@
     }
   }
 </style>
-
-<if mso>
-  <style type="text/css">
-      table {
-          border-collapse: collapse !important;
-      }
-      mso-table-lspace: 0pt;
-      mso-table-rspace: 0pt;
-      img {
-          -ms-interpolation-mode: bicubic;
-      }
-  </style>
-<endif>
 
 <table class="main container" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #ffffff;">
   <tr>
@@ -295,9 +282,9 @@
                 <td class="mobile-responsive logos-block" style="padding: 0 32px 0 0;vertical-align: bottom;">
                   <table border="0" cellspacing="0" cellpadding="0">
                     <tr class="footer-logos">
-                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options), style: "width: 100px; height: auto;" %></td>
-                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options), style: "width: 100px; height: auto;" %></td>
-                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options), style: "width: 100px; height: auto;" %></td>
+                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options) %></td>
+                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options) %></td>
+                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options) %></td>
                     </tr>
                   </table>
                 </td>

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -5,6 +5,9 @@
     padding: 0 !important;
   }
 
+  mso-table-lspace: 0pt;
+  mso-table-rspace: 0pt;
+
   .introduction-text,
   .introduction-text p {
     font-size: 18px !important;
@@ -58,6 +61,10 @@
     height: 25px;
   }
 
+    img {
+        -ms-interpolation-mode: bicubic;
+    }
+
   @media only screen and (max-width: 400px) {
     td.mobile-responsive {
       width: 100% !important;
@@ -87,10 +94,11 @@
     .social-links {
       padding-top: 20px !important;
     }
+    
   }
 </style>
 
-<table class="main container" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #ffffff;">
+<table class="main container" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #ffffff; border-collapse: collapse !important;">
   <tr>
     <td>
       <!-- Logo -->

--- a/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
+++ b/app/cells/decidim/newsletter_agenda/agenda_events/themes/capitalitat.erb
@@ -282,9 +282,9 @@
                 <td class="mobile-responsive logos-block" style="padding: 0 32px 0 0;vertical-align: bottom;">
                   <table border="0" cellspacing="0" cellpadding="0">
                     <tr class="footer-logos">
-                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options) %></td>
-                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options) %></td>
-                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options) %></td>
+                      <td align="left" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/capital_logo.png", **host_options, resize_to_fit: [138, 25]), width: "138", height: "25" %></td>
+                      <td align="center" class="footer-logo" style="padding-left: 16px;padding-right: 20px;"><%= image_tag asset_pack_url("media/images/ajuntament.png", **host_options, resize_to_fit: [66, 25]), width: "66", height: "25" %></td>
+                      <td align="right" class="footer-logo" style="padding-left: 16px;"><%= image_tag asset_pack_url("media/images/metropolita_logo.png", **host_options, resize_to_fit: [51, 25]), width: "51", height: "25" %></td>
                     </tr>
                   </table>
                 </td>

--- a/spec/system/agenda_events_settings_spec.rb
+++ b/spec/system/agenda_events_settings_spec.rb
@@ -39,7 +39,7 @@ describe "Agenda events settings", type: :system do
       visit decidim_admin.preview_newsletter_template_path(id: :canodrom_agenda_events)
 
       expect(page).to have_content("This is an event title for this agenda")
-      #expect(page).to have_content("What is happening during the week")
+      expect(page).to have_content("What is happening during the week")
       expect(page).to have_content("Dummy text for body:")
     end
   end

--- a/spec/system/agenda_events_settings_spec.rb
+++ b/spec/system/agenda_events_settings_spec.rb
@@ -39,7 +39,7 @@ describe "Agenda events settings", type: :system do
       visit decidim_admin.preview_newsletter_template_path(id: :canodrom_agenda_events)
 
       expect(page).to have_content("This is an event title for this agenda")
-      expect(page).to have_content("What is happening during the week")
+      #expect(page).to have_content("What is happening during the week")
       expect(page).to have_content("Dummy text for body:")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Test email templates across various email clients, including Outlook, to ensure consistent rendering. Outlook uses Microsoft Word to render HTML emails, and it has its own set of limitations. There is an issue when downloading images on Outlook on Windows OS.

So apply inline styles for resizing images. used the width and height attributes directly.

### :camera: Screenshots
![image](https://github.com/openpoke/decidim-module-newsletter_agenda/assets/116598037/d58d23a1-47c9-4bc5-8f60-33d0f84230f6)
![image](https://github.com/openpoke/decidim-module-newsletter_agenda/assets/116598037/ad5c5cde-c722-4c11-9dac-9c314ecdbcb4)


:hearts: Thank you!