### PR TITLE
Fix images on canodrom newsletter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GIT
 PATH
   remote: .
   specs:
-    decidim-newsletter_agenda (2.0)
+    decidim-newsletter_agenda (2.1)
       date_range_formatter
       decidim-admin (>= 0.29, < 0.30)
       decidim-core (>= 0.29, < 0.30)

--- a/app/cells/decidim/newsletter_templates/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_templates/agenda_events/themes/canodrom.erb
@@ -150,7 +150,7 @@
     color: #ffffff !important;
   }
   .footer-bottom__logo {
-    height: 40px;
+    height: 40px !important;
     padding-left: 35px;
   }
 
@@ -224,7 +224,7 @@
       <table class="introduction">
         <tr>
           <td style="text-align:center;padding-bottom: 50px;" colspan="2">
-            <%= image_tag asset_pack_url("media/images/logo-newsletter.png", **host_options) %>
+            <%= image_tag asset_pack_url("media/images/logo-newsletter.png", **host_options), alt: "" %>
           </td>
         </tr>
         <tr>
@@ -238,7 +238,7 @@
               <table class="row content image">
                 <tr align="center">
                   <th class="small-12 first columns" align="center">
-                    <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]), width: "653" %>
+                    <%= image_tag image_url(:main_image, resize_to_fit: [653, 436]), width: "653", alt: "" %>
                   </th>
                   <th class="expander"></th>
                 </tr>
@@ -276,7 +276,7 @@
                       <div class="box-image">
                         <% if has_image?("body_box_image_#{num}") %>
                           <%= link_to link_for("body_box_link_url_#{num}") do %>
-                            <%= image_tag(image_url("body_box_image_#{num}"), width: "238", style: "width:100%; max-width:500px; display:block; margin:0 auto;") %>
+                            <%= image_tag(image_url("body_box_image_#{num}"), width: "238", alt: translated_text_for("body_box_title_#{num}"), style: "width:100%; max-width:500px; display:block; margin:0 auto;") %>
                           <% end %>
                         <% end %>
                       </div>
@@ -305,7 +305,7 @@
         <tr style="text-align: center;vertical-align: middle;">
           <td class="bottom" width="580px" height="290px" style="text-align: center;vertical-align: middle;">
             <%= translated_text_for :body_final_text %>
-            <%= image_tag asset_pack_url("media/images/down-lilac.png", **host_options) %>
+            <%= image_tag asset_pack_url("media/images/down-lilac.png", **host_options), alt: "" %>
           </td>
         </tr>
       </table>
@@ -323,7 +323,7 @@
           <% (1..3).each do |num| %>
             <td class="footer-box" style="padding: 10px;margin-bottom: 30px;" width="33%">
               <div class="box-image">
-                <%= image_tag(image_url("footer_box_image_#{num}", resize_to_fill: [152, 101]), width: "152", height: "101") if has_image?("footer_box_image_#{num}") %>
+                <%= image_tag(image_url("footer_box_image_#{num}", resize_to_fill: [302, 202]), width: "152", height: "101", alt: translated_text_for("footer_box_title_#{num}")) if has_image?("footer_box_image_#{num}") %>
               </div>
               <div class="footer-box-date-time">
                 <%= translated_text_for "footer_box_date_time_#{num}" %>
@@ -360,7 +360,7 @@
         <table class="footer-logo" style="margin: 0;">
           <tr>
             <td class="footer-bottom" style="padding: 20px 0;">
-              <%= image_tag footer_image_url, class: "footer-bottom__logo", width: "150", height: "50" %>
+              <%= image_tag footer_image_url, class: "footer-bottom__logo", width: "150", height: "50", alt: "" %>
             </td>
           </tr>
         </table>

--- a/app/cells/decidim/newsletter_templates/agenda_events/themes/canodrom.erb
+++ b/app/cells/decidim/newsletter_templates/agenda_events/themes/canodrom.erb
@@ -191,7 +191,11 @@
     }
 
     .box-image {
-      width: 100% !important;
+      width: 50% !important;
+    }
+
+    .box-image img {
+      height: auto;
     }
 
     .footer-bottom {

--- a/lib/decidim/newsletter_agenda/version.rb
+++ b/lib/decidim/newsletter_agenda/version.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module NewsletterAgenda
-    VERSION = "2.0"
+    VERSION = "2.1"
     DECIDIM_VERSION = { github: "decidim/decidim", branch: "release/0.29-stable" }.freeze
     COMPAT_DECIDIM_VERSION = [">= 0.29", "< 0.30"].freeze
   end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decidim_module_newsletter_agneda",
-  "version": "2.0",
+  "version": "2.1",
   "description": "A 3 steps proposals for Decidim",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Whit this PR we are trying to fix:

On thunderbird mobile:
- The footer image exceeds the size given to it
- The footer images are stretched and can't be seen correctly

On desktop
- The footer images have lower resolution than expected

Accessibility:
- There were no alt text for the images. Since some are only for aesthetics they have a blank alt, but those that reference an event will have the title of the event as alt text.